### PR TITLE
Merge the merging-practices changes back into main

### DIFF
--- a/info.md
+++ b/info.md
@@ -7,3 +7,5 @@ No multi-person project can do without task and issue branches. The only possibl
 ## Creating Branches
 
 Branch management begins with creating an appropriately named branch. Note that that branch will be checked out: always note that you are working in the correct branch afterwards.
+
+See ["Merging"](merging.md) for best practices on merging branches.

--- a/merging.md
+++ b/merging.md
@@ -2,4 +2,8 @@
 
 ### Feature or fix branch to main
 
-Before merging from a feature or fix branch back to the main branch (e.g. `main`, `master`, `trunk`), you **must** merge any changed from the main branch into the feature or fix branch. 
+Before merging from a feature or fix branch back to the main branch (e.g. `main`, `master`, `trunk`), you **must** merge any changed from the main branch into the feature or fix branch.
+
+THe merge from the main branch to the feature branch (prior to the merge in the other direction) must be done with a _discpline_. For example, we may do this on a daily basis&mdash;that is, while working on a feature branch, the developer would merge any new changes from the main branch into the feature branch every day.
+
+In any event, immediately prior to merging from a feature or fix branch to the main branch, a merge in the opposite direction **must** be performed, to reduce as much as possible the need to resolve conflicts when merging to the main branch.


### PR DESCRIPTION
I've started writing up recommended/required practices for merging; let's include these in main, even while still in-progress.